### PR TITLE
Fix imports for Werkzeug 1.0

### DIFF
--- a/flask_fanstatic.py
+++ b/flask_fanstatic.py
@@ -1,9 +1,9 @@
 from fanstatic import (init_needed, del_needed, Publisher, get_library_registry,
                        DEFAULT_SIGNATURE, Resource, Library, Group)
 from flask import Blueprint, g, Markup, current_app, request
-from werkzeug import cached_property
+from werkzeug.utils import cached_property
 from werkzeug.utils import import_string
-from werkzeug.wsgi import DispatcherMiddleware
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 
 class Fanstatic(object):


### PR DESCRIPTION
The API for Werkzeug 1.0 seems to have changed, and in a breaking way.

flask-fanstatic imported cached_property and DispatcherMiddleware;
this patch updates the package names to the new packages.

This is a patch for flask-fanstatic issue #3